### PR TITLE
Open created templates directly in debug apps

### DIFF
--- a/src/mixins/AddShareRequestByTemplate.ts
+++ b/src/mixins/AddShareRequestByTemplate.ts
@@ -1,4 +1,5 @@
 import { RelationshipTemplateContentJSON, RequestItemGroupJSON, RequestJSON } from "@nmshd/content"
+import { exec } from "child_process"
 import { DateTime } from "luxon"
 import prompts from "prompts"
 import qrcode from "qrcode-terminal"
@@ -243,6 +244,28 @@ export function AddShareRequestByTemplate<TBase extends ConnectorTUIBaseConstruc
       })
 
       if (!result.open) return
+
+      const androidOrIOS = await prompts({
+        message: "Is the connected device Android or iOS?",
+        type: "select",
+        name: "deviceType",
+        choices: [
+          { title: "Android", value: "Android" },
+          { title: "iOS", value: "iOS" },
+        ],
+      })
+
+      if (!androidOrIOS.deviceType) return
+
+      const command = androidOrIOS.deviceType === "Android" ? `adb shell am start -a android.intent.action.VIEW -d "${url}"` : `xcrun simctl openurl booted "${url}"`
+
+      await new Promise<void>((resolve) => {
+        exec(command, (err, _, __) => {
+          if (err) return console.error(`Error executing command: ${err.message}`)
+
+          resolve()
+        })
+      })
     }
   }
 }

--- a/src/mixins/AddShareRequestByTemplate.ts
+++ b/src/mixins/AddShareRequestByTemplate.ts
@@ -234,6 +234,15 @@ export function AddShareRequestByTemplate<TBase extends ConnectorTUIBaseConstruc
       const url = template.result.reference.url
       console.log(url)
       qrcode.generate(url, { small: true })
+
+      const result = await prompts({
+        message: "Do you want to open the link on a connected device?",
+        type: "confirm",
+        name: "open",
+        initial: false,
+      })
+
+      if (!result.open) return
     }
   }
 }


### PR DESCRIPTION
This adds a new option to directly open the link of the created template in the debugger (adb for Android and running ios Simulators).