### PR TITLE
The connectors display name is not always the one configured

### DIFF
--- a/src/mixins/AddShareRequestByTemplate.ts
+++ b/src/mixins/AddShareRequestByTemplate.ts
@@ -103,9 +103,7 @@ export function AddShareRequestByTemplate<TBase extends ConnectorTUIBaseConstruc
       const response = await this.connectorClient.attributes.getOwnRepositoryAttributes({ "content.value.@type": "DisplayName" })
       const displayNameWithValue = response.result.find((attr) => attr.content.value["@type"] === "DisplayName" && attr.content.value.value === displayName)
 
-      if (response.result.length > 0) {
-        return response.result[0]
-      }
+      if (displayNameWithValue) return displayNameWithValue
 
       const createAttributeResponse = await this.connectorClient.attributes.createRepositoryAttribute({
         content: {

--- a/src/mixins/AddShareRequestByTemplate.ts
+++ b/src/mixins/AddShareRequestByTemplate.ts
@@ -100,17 +100,8 @@ export function AddShareRequestByTemplate<TBase extends ConnectorTUIBaseConstruc
     }
 
     private async getOrCreateConnectorDisplayName(displayName: string) {
-      const response = await this.connectorClient.attributes.getValidAttributes({
-        content: {
-          owner: this.connectorAddress,
-          value: {
-            "@type": "DisplayName",
-          },
-        },
-        shareInfo: {
-          peer: "!",
-        },
-      })
+      const response = await this.connectorClient.attributes.getOwnRepositoryAttributes({ "content.value.@type": "DisplayName" })
+      const displayNameWithValue = response.result.find((attr) => attr.content.value["@type"] === "DisplayName" && attr.content.value.value === displayName)
 
       if (response.result.length > 0) {
         return response.result[0]


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
