### PR TITLE
Use main for shared dependency workflows

### DIFF
--- a/.github/workflows/dependency-security-maintenance.yml
+++ b/.github/workflows/dependency-security-maintenance.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   npm-audit:
-    uses: js-soft/github-actions/.github/workflows/dependency-security-maintenance.yml@7341f0fefe5319a41ead6e19d833f142a306159a # main
+    uses: js-soft/github-actions/.github/workflows/dependency-security-maintenance.yml@main
     with:
       reviewers: nmshd/npm-dependency-update-reviewers
     secrets:

--- a/.github/workflows/weekly-release-of-dependency-updates.yml
+++ b/.github/workflows/weekly-release-of-dependency-updates.yml
@@ -14,6 +14,6 @@ concurrency:
 
 jobs:
   release:
-    uses: js-soft/github-actions/.github/workflows/release-dependency-updates.yml@7341f0fefe5319a41ead6e19d833f142a306159a # main
+    uses: js-soft/github-actions/.github/workflows/release-dependency-updates.yml@main
     secrets:
       github-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary

- Point the dependency security maintenance workflow at `js-soft/github-actions` on `main` instead of a pinned commit.
- Point the weekly release dependency updates workflow at `js-soft/github-actions` on `main` instead of a pinned commit.

## Validation

- Not run; workflow reference-only change.